### PR TITLE
Rename `BumpAlloc` -> `Arena` and simplify

### DIFF
--- a/include/Math/AxisTypes.hpp
+++ b/include/Math/AxisTypes.hpp
@@ -23,7 +23,7 @@
 /// that are evaluated upon assignments, e.g. `<<` or `+=`.
 ///
 /// All the PtrVector/PtrMatrix types are trivially destructible, copyable, etc
-/// Their lifetimes are governed by the BumpAlloc or RAII type used to back
+/// Their lifetimes are governed by the Arena or RAII type used to back
 /// them.
 namespace poly::math {
 using utils::invariant;

--- a/include/Math/Constructors.hpp
+++ b/include/Math/Constructors.hpp
@@ -5,19 +5,19 @@
 #include "Utilities/Allocators.hpp"
 
 namespace poly::math {
-using utils::BumpAlloc, utils::WBumpAlloc;
+using utils::Arena, utils::WArena;
 template <class T>
 constexpr auto vector(std::allocator<T>, unsigned int M) -> Vector<T> {
   return Vector<T>(M);
 }
 template <class T>
-constexpr auto vector(WBumpAlloc<T> alloc, unsigned int M)
+constexpr auto vector(WArena<T> alloc, unsigned int M)
   -> ResizeableView<T, unsigned> {
   return {alloc.allocate(M), M, M};
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto vector(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc,
-                      unsigned int M) -> ResizeableView<T, unsigned> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto vector(Arena<SlabSize, BumpUp> &alloc, unsigned int M)
+  -> ResizeableView<T, unsigned> {
   return {alloc.template allocate<T>(M), M, M};
 }
 
@@ -26,15 +26,15 @@ constexpr auto vector(std::allocator<T>, unsigned int M, T x) -> Vector<T> {
   return {M, x};
 }
 template <class T>
-constexpr auto vector(WBumpAlloc<T> alloc, unsigned int M, T x)
+constexpr auto vector(WArena<T> alloc, unsigned int M, T x)
   -> ResizeableView<T, unsigned> {
   ResizeableView<T, unsigned> a{alloc.allocate(M), M, M};
   a.fill(x);
   return a;
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto vector(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc,
-                      unsigned int M, T x) -> ResizeableView<T, unsigned> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto vector(Arena<SlabSize, BumpUp> &alloc, unsigned int M, T x)
+  -> ResizeableView<T, unsigned> {
   ResizeableView<T, unsigned> a{alloc.template allocate<T>(M), M, M};
   a.fill(x);
   return a;
@@ -45,13 +45,13 @@ constexpr auto matrix(std::allocator<T>, unsigned int M) -> SquareMatrix<T> {
   return SquareDims{M};
 }
 template <class T>
-constexpr auto matrix(WBumpAlloc<T> alloc, unsigned int M)
+constexpr auto matrix(WArena<T> alloc, unsigned int M)
   -> MutSquarePtrMatrix<T> {
   return {alloc.allocate(M * M), SquareDims{M}};
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto matrix(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc,
-                      unsigned int M) -> MutSquarePtrMatrix<T> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto matrix(Arena<SlabSize, BumpUp> &alloc, unsigned int M)
+  -> MutSquarePtrMatrix<T> {
   return {alloc.template allocate<T>(M * M), SquareDims{M}};
 }
 template <class T>
@@ -60,15 +60,15 @@ constexpr auto matrix(std::allocator<T>, unsigned int M, T x)
   return {SquareDims{M}, x};
 }
 template <class T>
-constexpr auto matrix(WBumpAlloc<T> alloc, unsigned int M, T x)
+constexpr auto matrix(WArena<T> alloc, unsigned int M, T x)
   -> MutSquarePtrMatrix<T> {
   MutSquarePtrMatrix<T> A{alloc.allocate(M * M), SquareDims{M}};
   A.fill(x);
   return A;
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto matrix(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc,
-                      unsigned int M, T x) -> MutSquarePtrMatrix<T> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto matrix(Arena<SlabSize, BumpUp> &alloc, unsigned int M, T x)
+  -> MutSquarePtrMatrix<T> {
   MutSquarePtrMatrix<T> A{alloc.template allocate<T>(M * M), SquareDims{M}};
   A.fill(x);
   return A;
@@ -79,13 +79,12 @@ constexpr auto matrix(std::allocator<T>, Row M, Col N) -> DenseMatrix<T> {
   return DenseDims{M, N};
 }
 template <class T>
-constexpr auto matrix(WBumpAlloc<T> alloc, Row M, Col N)
-  -> MutDensePtrMatrix<T> {
+constexpr auto matrix(WArena<T> alloc, Row M, Col N) -> MutDensePtrMatrix<T> {
   return {alloc.allocate(M * N), DenseDims{M, N}};
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto matrix(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc, Row M,
-                      Col N) -> MutDensePtrMatrix<T> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto matrix(Arena<SlabSize, BumpUp> &alloc, Row M, Col N)
+  -> MutDensePtrMatrix<T> {
   return {alloc.template allocate<T>(M * N), M, N};
 }
 template <class T>
@@ -93,15 +92,15 @@ constexpr auto matrix(std::allocator<T>, Row M, Col N, T x) -> DenseMatrix<T> {
   return {DenseDims{M, N}, x};
 }
 template <class T>
-constexpr auto matrix(WBumpAlloc<T> alloc, Row M, Col N, T x)
+constexpr auto matrix(WArena<T> alloc, Row M, Col N, T x)
   -> MutDensePtrMatrix<T> {
   MutDensePtrMatrix<T> A{alloc.allocate(M * N), DenseDims{M, N}};
   A.fill(x);
   return A;
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto matrix(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc, Row M,
-                      Col N, T x) -> MutDensePtrMatrix<T> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto matrix(Arena<SlabSize, BumpUp> &alloc, Row M, Col N, T x)
+  -> MutDensePtrMatrix<T> {
   MutDensePtrMatrix<T> A{alloc.template allocate<T>(M * N), DenseDims{M, N}};
   A.fill(x);
   return A;
@@ -114,15 +113,15 @@ constexpr auto identity(std::allocator<T>, unsigned int M) -> SquareMatrix<T> {
   return A;
 }
 template <class T>
-constexpr auto identity(WBumpAlloc<T> alloc, unsigned int M)
+constexpr auto identity(WArena<T> alloc, unsigned int M)
   -> MutSquarePtrMatrix<T> {
   MutSquarePtrMatrix<T> A{matrix(alloc, M, T{})};
   A.diag() << T{1};
   return A;
 }
-template <class T, size_t SlabSize, bool BumpUp, size_t MinAlignment>
-constexpr auto identity(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc,
-                        unsigned int M) -> MutSquarePtrMatrix<T> {
+template <class T, size_t SlabSize, bool BumpUp>
+constexpr auto identity(Arena<SlabSize, BumpUp> &alloc, unsigned int M)
+  -> MutSquarePtrMatrix<T> {
   MutSquarePtrMatrix<T> A{matrix(alloc, M, T{})};
   A.diag() << T{1};
   return A;
@@ -130,11 +129,21 @@ constexpr auto identity(BumpAlloc<SlabSize, BumpUp, MinAlignment> &alloc,
 
 template <typename T, typename I>
 concept Alloc = requires(T t, unsigned int M, Row r, Col c, I i) {
-  { identity<I>(t, M) } -> std::convertible_to<MutSquarePtrMatrix<I>>;
-  { matrix<I>(t, M) } -> std::convertible_to<MutSquarePtrMatrix<I>>;
-  { matrix<I>(t, M, i) } -> std::convertible_to<MutSquarePtrMatrix<I>>;
-  { matrix<I>(t, r, c) } -> std::convertible_to<MutDensePtrMatrix<I>>;
-  { matrix(t, r, c, i) } -> std::convertible_to<MutDensePtrMatrix<I>>;
-  { vector<I>(t, M) } -> std::convertible_to<MutPtrVector<I>>;
-};
+                  {
+                    identity<I>(t, M)
+                    } -> std::convertible_to<MutSquarePtrMatrix<I>>;
+                  {
+                    matrix<I>(t, M)
+                    } -> std::convertible_to<MutSquarePtrMatrix<I>>;
+                  {
+                    matrix<I>(t, M, i)
+                    } -> std::convertible_to<MutSquarePtrMatrix<I>>;
+                  {
+                    matrix<I>(t, r, c)
+                    } -> std::convertible_to<MutDensePtrMatrix<I>>;
+                  {
+                    matrix(t, r, c, i)
+                    } -> std::convertible_to<MutDensePtrMatrix<I>>;
+                  { vector<I>(t, M) } -> std::convertible_to<MutPtrVector<I>>;
+                };
 } // namespace poly::math

--- a/include/Math/NormalForm.hpp
+++ b/include/Math/NormalForm.hpp
@@ -29,8 +29,8 @@ constexpr auto gcdxScale(int64_t a, int64_t b) -> std::array<int64_t, 4> {
 }
 // zero out below diagonal
 constexpr void zeroSupDiagonal(MutPtrMatrix<int64_t> A,
-                               MutSquarePtrMatrix<int64_t> K, ptrdiff_t i, Row M,
-                               Col N) {
+                               MutSquarePtrMatrix<int64_t> K, ptrdiff_t i,
+                               Row M, Col N) {
   ptrdiff_t minMN = std::min(ptrdiff_t(M), ptrdiff_t(N));
   for (ptrdiff_t j = i + 1; j < M; ++j) {
     int64_t Aii = A(i, i);
@@ -68,8 +68,8 @@ constexpr void zeroSupDiagonal(MutPtrMatrix<int64_t> A,
 // This method is only called by orthogonalize, hence we can assume
 // (Akk == 1) || (Akk == -1)
 constexpr void zeroSubDiagonal(MutPtrMatrix<int64_t> A,
-                               MutSquarePtrMatrix<int64_t> K, ptrdiff_t k, Row M,
-                               Col N) {
+                               MutSquarePtrMatrix<int64_t> K, ptrdiff_t k,
+                               Row M, Col N) {
   int64_t Akk = A(k, k);
   if (Akk == -1) {
     for (ptrdiff_t m = 0; m < N; ++m) A(k, m) *= -1;
@@ -301,7 +301,8 @@ constexpr void reduceColumn(MutPtrMatrix<int64_t> A, Col c, Row r) {
 }
 // treats A as stacked on top of B
 constexpr void reduceColumnStack(MutPtrMatrix<int64_t> A,
-                                 MutPtrMatrix<int64_t> B, ptrdiff_t c, ptrdiff_t r) {
+                                 MutPtrMatrix<int64_t> B, ptrdiff_t c,
+                                 ptrdiff_t r) {
   zeroSupDiagonal(B, c, r);
   reduceSubDiagonalStack(B, A, c, r);
 }
@@ -320,8 +321,8 @@ constexpr void removeZeroRows(MutDensePtrMatrix<int64_t> &A) {
 }
 
 // pass by value, returns number of rows to truncate
-constexpr auto simplifySystemImpl(MutPtrMatrix<int64_t> A, ptrdiff_t colInit = 0)
-  -> Row {
+constexpr auto simplifySystemImpl(MutPtrMatrix<int64_t> A,
+                                  ptrdiff_t colInit = 0) -> Row {
   auto [M, N] = A.size();
   for (ptrdiff_t r = 0, c = colInit; c < N && r < M; ++c)
     if (!pivotRows(A, Col{c}, M, Row{r})) reduceColumn(A, Col{c}, Row{r++});
@@ -361,7 +362,8 @@ constexpr void simplifySystem(MutPtrMatrix<int64_t> &A,
 }
 [[nodiscard]] constexpr auto hermite(IntMatrix A)
   -> std::pair<IntMatrix, SquareMatrix<int64_t>> {
-  SquareMatrix<int64_t> U{SquareMatrix<int64_t>::identity(ptrdiff_t(A.numRow()))};
+  SquareMatrix<int64_t> U{
+    SquareMatrix<int64_t>::identity(ptrdiff_t(A.numRow()))};
   simplifySystemsImpl({A, U});
   return std::make_pair(std::move(A), std::move(U));
 }
@@ -490,7 +492,8 @@ constexpr auto pivotRowsBareiss(MutPtrMatrix<int64_t> A, ptrdiff_t i, Row M,
   if (j != piv) swap(A, j, piv);
   return ptrdiff_t(piv);
 }
-constexpr void bareiss(MutPtrMatrix<int64_t> A, MutPtrVector<ptrdiff_t> pivots) {
+constexpr void bareiss(MutPtrMatrix<int64_t> A,
+                       MutPtrVector<ptrdiff_t> pivots) {
   const auto [M, N] = A.size();
   invariant(ptrdiff_t(pivots.size()), min(M, N));
   int64_t prev = 1, pivInd = 0;
@@ -520,8 +523,8 @@ constexpr void bareiss(MutPtrMatrix<int64_t> A, MutPtrVector<ptrdiff_t> pivots) 
 // doesn't reduce last row (assumes you're solving for it)
 constexpr auto updateForNewRow(MutPtrMatrix<int64_t> A) -> ptrdiff_t {
   // use existing rows to reduce
-  ptrdiff_t M = ptrdiff_t(A.numRow()), N = ptrdiff_t(A.numCol()), MM = M - 1, NN = N - 1,
-         n = 0, i, j = std::numeric_limits<ptrdiff_t>::max();
+  ptrdiff_t M = ptrdiff_t(A.numRow()), N = ptrdiff_t(A.numCol()), MM = M - 1,
+            NN = N - 1, n = 0, i, j = std::numeric_limits<ptrdiff_t>::max();
   for (ptrdiff_t m = 0; m < MM; ++m) {
 #ifndef NDEBUG
     if (!allZero(A(m, _(0, n)))) __builtin_trap();
@@ -640,7 +643,7 @@ constexpr void nullSpace11(DenseMatrix<int64_t> &B, DenseMatrix<int64_t> &A) {
   // free their own ptrs; we'd have to still store either the old pointer or the
   // offset.
   // However, this may be reasonable given an implementation
-  // that takes a `BumpAlloc<>` as input to allocate `B`, as
+  // that takes a `Arena<>` as input to allocate `B`, as
   // then we don't need to track the pointer.
   std::copy_n(B.data() + ptrdiff_t(R * M), ptrdiff_t(D * M), B.data());
   B.truncate(D);

--- a/include/Math/Simplex.hpp
+++ b/include/Math/Simplex.hpp
@@ -659,7 +659,7 @@ public:
   // A(:,1:end)*x <= A(:,0)
   // B(:,1:end)*x == B(:,0)
   // returns a Simplex if feasible, and an empty `Optional` otherwise
-  static constexpr auto positiveVariables(Arena<> &alloc, PtrMatrix<int64_t> A,
+  static constexpr auto positiveVariables(Arena<> *alloc, PtrMatrix<int64_t> A,
                                           PtrMatrix<int64_t> B)
     -> Optional<Simplex *> {
     invariant(A.numCol() == B.numCol());
@@ -670,7 +670,7 @@ public:
     // each of these will require an augment variable
     for (unsigned i = 0; i < numSlack; ++i) varCap += A(i, 0) < 0;
     // try to avoid reallocating
-    auto checkpoint{alloc.checkpoint()};
+    auto checkpoint{alloc->checkpoint()};
     Simplex *simplex{
       Simplex::create(alloc, numCon, numVar + numSlack, numCon, varCap)};
     // construct:
@@ -685,10 +685,10 @@ public:
     // for (ptrdiff_t i = 0; i < numSlack; ++i) consts[i] = A(i, 0);
     // for (ptrdiff_t i = 0; i < numStrict; ++i) consts[i + numSlack] = B(i, 0);
     if (!simplex->initiateFeasible()) return simplex;
-    alloc.rollback(checkpoint);
+    alloc->rollback(checkpoint);
     return nullptr;
   }
-  static constexpr auto positiveVariables(Arena<> &alloc, PtrMatrix<int64_t> A)
+  static constexpr auto positiveVariables(Arena<> *alloc, PtrMatrix<int64_t> A)
     -> Optional<Simplex *> {
     unsigned numVar = unsigned(A.numCol()) - 1, numSlack = unsigned(A.numRow()),
              numCon = numSlack, varCap = numVar + numSlack;
@@ -696,7 +696,7 @@ public:
     // each of these will require an augment variable
     for (unsigned i = 0; i < numSlack; ++i) varCap += A(i, 0) < 0;
     // try to avoid reallocating
-    auto checkpoint{alloc.checkpoint()};
+    auto checkpoint{alloc->checkpoint()};
     Simplex *simplex{
       Simplex::create(alloc, numCon, numVar + numSlack, numCon, varCap)};
     // construct:
@@ -708,12 +708,12 @@ public:
     // for (ptrdiff_t i = 0; i < numSlack; ++i) consts[i] = A(i, 0);
     simplex->getConstants() << A(_, 0);
     if (!simplex->initiateFeasible()) return simplex;
-    alloc.rollback(checkpoint);
+    alloc->rollback(checkpoint);
     return nullptr;
   }
 
-  constexpr void pruneBounds(Arena<> &alloc, ptrdiff_t numSlack = 0) {
-    auto p = alloc.scope();
+  constexpr void pruneBounds(Arena<> *alloc, ptrdiff_t numSlack = 0) {
+    auto p = alloc->scope();
     Simplex *simplex{Simplex::create(alloc, numConstraints, numVars,
                                      constraintCapacity, varCapacity)};
     // Simplex simplex{getNumCons(), getNumVars(), getNumSlack(), 0};
@@ -763,7 +763,7 @@ public:
   // }
   // check if a solution exists such that `x` can be true.
   // returns `true` if unsatisfiable
-  [[nodiscard]] constexpr auto unSatisfiable(Arena<> &alloc,
+  [[nodiscard]] constexpr auto unSatisfiable(Arena<> alloc,
                                              PtrVector<int64_t> x,
                                              ptrdiff_t off) const -> bool {
     // is it a valid solution to set the first `x.size()` variables to
@@ -774,8 +774,7 @@ public:
     // is satisfiable.
     const ptrdiff_t numCon = getNumCons(), numVar = getNumVars(),
                     numFix = x.size();
-    auto p = alloc.scope();
-    Simplex *subSimp{Simplex::create(alloc, numCon, numVar - numFix)};
+    Simplex *subSimp{Simplex::create(&alloc, numCon, numVar - numFix)};
     // subSimp.tableau(0, 0) = 0;
     // subSimp.tableau(0, 1) = 0;
     auto fC{getTableau()};
@@ -789,14 +788,14 @@ public:
     // returns `true` if unsatisfiable
     return subSimp->initiateFeasible();
   }
-  [[nodiscard]] constexpr auto satisfiable(Arena<> &alloc, PtrVector<int64_t> x,
+  [[nodiscard]] constexpr auto satisfiable(Arena<> alloc, PtrVector<int64_t> x,
                                            ptrdiff_t off) const -> bool {
     return !unSatisfiable(alloc, x, off);
   }
   // check if a solution exists such that `x` can be true.
   // zeros remaining rows
   [[nodiscard]] constexpr auto
-  unSatisfiableZeroRem(Arena<> &alloc, PtrVector<int64_t> x, ptrdiff_t off,
+  unSatisfiableZeroRem(Arena<> alloc, PtrVector<int64_t> x, ptrdiff_t off,
                        ptrdiff_t numRow) const -> bool {
     // is it a valid solution to set the first `x.size()` variables to
     // `x`? first, check that >= 0 constraint is satisfied
@@ -806,8 +805,7 @@ public:
     // is satisfiable.
     invariant(numRow <= getNumCons());
     const ptrdiff_t numFix = x.size();
-    auto p = alloc.scope();
-    Simplex *subSimp{Simplex::create(alloc, numRow, off++)};
+    Simplex *subSimp{Simplex::create(&alloc, numRow, off++)};
     auto fC{getConstraints()};
     auto sC{subSimp->getConstraints()};
     sC(_, 0) << fC(_(begin, numRow), 0) -
@@ -820,13 +818,12 @@ public:
   /// (i.e., indsFree + indOne == index of var pinned to 1)
   /// numRow is number of rows used, extras are dropped
   // [[nodiscard]] constexpr auto
-  [[nodiscard]] inline auto
-  unSatisfiableZeroRem(Arena<> &alloc, ptrdiff_t iFree,
-                       std::array<ptrdiff_t, 2> inds, ptrdiff_t numRow) const
+  [[nodiscard]] inline auto unSatisfiableZeroRem(Arena<> alloc, ptrdiff_t iFree,
+                                                 std::array<ptrdiff_t, 2> inds,
+                                                 ptrdiff_t numRow) const
     -> bool {
     invariant(numRow <= getNumCons());
-    auto p = alloc.scope();
-    Simplex *subSimp{Simplex::create(alloc, numRow, iFree++)};
+    Simplex *subSimp{Simplex::create(&alloc, numRow, iFree++)};
     auto fC{getConstraints()};
     auto sC{subSimp->getConstraints()};
     auto r = _(0, numRow);
@@ -835,7 +832,7 @@ public:
     return subSimp->initiateFeasible();
   }
   [[nodiscard]] constexpr auto
-  satisfiableZeroRem(Arena<> &alloc, PtrVector<int64_t> x, ptrdiff_t off,
+  satisfiableZeroRem(Arena<> alloc, PtrVector<int64_t> x, ptrdiff_t off,
                      ptrdiff_t numRow) const -> bool {
     return !unSatisfiableZeroRem(alloc, x, off, numRow);
   }
@@ -856,17 +853,17 @@ public:
       }
     }
   }
-  static constexpr auto create(Arena<> &alloc, unsigned numCon, unsigned numVar)
+  static constexpr auto create(Arena<> *alloc, unsigned numCon, unsigned numVar)
     -> NotNull<Simplex> {
     return create(alloc, numCon, numVar, numCon, numVar + numCon);
   }
-  static constexpr auto create(Arena<> &alloc, unsigned numCon, unsigned numVar,
+  static constexpr auto create(Arena<> *alloc, unsigned numCon, unsigned numVar,
                                unsigned conCap, unsigned varCap)
     -> NotNull<Simplex> {
 
     size_t memNeeded = tableauOffset(conCap, varCap) +
                        sizeof(value_type) * reservedTableau(conCap, varCap);
-    auto *mem = (Simplex *)alloc.allocate(sizeof(Simplex) + memNeeded);
+    auto *mem = (Simplex *)alloc->allocate(sizeof(Simplex) + memNeeded);
     mem->numConstraints = numCon;
     mem->numVars = numVar;
     mem->constraintCapacity = conCap;
@@ -901,13 +898,13 @@ public:
   }
 
   static constexpr auto
-  create(Arena<> &alloc, unsigned numCon,
+  create(Arena<> *alloc, unsigned numCon,
          unsigned numVar, // NOLINT(bugprone-easily-swappable-parameters)
          unsigned numSlack) -> NotNull<Simplex> {
     unsigned conCap = numCon, varCap = numVar + numSlack + numCon;
     return create(alloc, numCon, numVar, conCap, varCap);
   }
-  constexpr auto copy(Arena<> &alloc) const -> NotNull<Simplex> {
+  constexpr auto copy(Arena<> *alloc) const -> NotNull<Simplex> {
     NotNull<Simplex> res =
       create(alloc, getNumCons(), getNumVars(), getConCap(), getVarCap());
     *res << *this;

--- a/include/Utilities/Allocators.hpp
+++ b/include/Utilities/Allocators.hpp
@@ -2,7 +2,6 @@
 
 #include "Utilities/Invariant.hpp"
 #include "Utilities/Valid.hpp"
-#include <Containers/UnrolledList.hpp>
 #include <algorithm>
 #include <bit>
 #include <cstddef>
@@ -53,31 +52,58 @@ void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
 
 namespace poly::utils {
 
-template <size_t SlabSize, bool BumpUp, size_t MinAlignment> class BumpAlloc {
-  static_assert(std::has_single_bit(MinAlignment));
+/// Each slab reserves the first 16 bytes for
+/// 1. a pointer to the next slab
+/// 2. a pointer to the first slab
+template <size_t SlabSize = 16384, bool BumpUp = true> class Arena {
+  static constexpr size_t Alignment = alignof(std::max_align_t);
+  static constexpr auto align(size_t x) -> size_t {
+    return (x + Alignment - 1) & ~(Alignment - 1);
+  }
+  // meta data is always in front, so we don't have to handle
+  // the rare accidental case of huge slabs separately.
+  static constexpr size_t MetaSize = align(2 * sizeof(void *));
+  static_assert(std::has_single_bit(Alignment));
 
 public:
   static constexpr bool BumpDown = !BumpUp;
   using value_type = void;
-  [[using gnu: returns_nonnull, alloc_size(2), alloc_align(3),
-    malloc]] constexpr auto
-  allocate(size_t Size, size_t Align) -> void * {
-    if (Size > SlabSize / 2) {
-      void *p = std::aligned_alloc(Align, Size);
-      pushOldSlab(p);
 #ifndef NDEBUG
-      std::fill_n((char *)(p), Size, -1);
-#endif
-      return p;
-    }
-    auto p = (Align > MinAlignment) ? bumpAlloc(Size, Align) : bumpAlloc(Size);
-    __asan_unpoison_memory_region(p, Size);
-    __msan_allocated_memory(p, Size);
-#ifndef NDEBUG
-    if ((MinAlignment >= alignof(int64_t)) && ((Size & 7) == 0)) {
+  constexpr void fillWithJunk(void *p, size_t Size) {
+    if (((Size & 7) == 0)) {
       std::fill_n(static_cast<std::int64_t *>(p), Size >> 3,
                   std::numeric_limits<std::int64_t>::min());
     } else std::fill_n((char *)(p), Size, -1);
+  }
+#endif
+  [[using gnu: returns_nonnull, alloc_size(2), assume_aligned(Alignment),
+    malloc]] constexpr auto
+  allocate(size_t Size) -> void * {
+    // we allocate this slab and insert it.
+    // this is a pretty bad path.
+    if (Size > SlabSize - MetaSize) [[unlikely]] {
+      void *p = std::malloc(Size + MetaSize);
+      void *q = std::malloc(SlabSize);
+      void **meta = static_cast<void **>(p);
+      void **oldMeta = static_cast<void **>(sEnd);
+      void **newMeta = static_cast<void **>(q);
+      void *firstSlab = oldMeta[1];
+      oldMeta[0] = p;
+      meta[0] = q;
+      meta[1] = firstSlab;
+      newMeta[0] = nullptr;
+      newMeta[1] = firstSlab;
+      initSlab(q);
+#ifndef NDEBUG
+      fillWithJunk(static_cast<char *>(p) + MetaSize, Size);
+#endif
+      return static_cast<char *>(p) + MetaSize;
+    }
+    auto p = bumpAlloc(Size);
+    __asan_unpoison_memory_region(p, Size);
+    __msan_allocated_memory(p, Size);
+#ifndef NDEBUG
+    fillWithJunk(p, Size);
 #endif
     return p;
   }
@@ -85,22 +111,21 @@ public:
   [[gnu::returns_nonnull, gnu::flatten]] constexpr auto allocate(size_t N = 1)
     -> T * {
     static_assert(std::is_trivially_destructible_v<T>,
-                  "BumpAlloc only supports trivially destructible types.");
-    return static_cast<T *>(allocate(N * sizeof(T), alignof(T)));
+                  "Arena only supports trivially destructible types.");
+    return static_cast<T *>(allocate(N * sizeof(T)));
   }
   template <typename T, class... Args>
   [[gnu::returns_nonnull, gnu::flatten]] constexpr auto create(Args &&...args)
     -> T * {
     static_assert(std::is_trivially_destructible_v<T>,
-                  "BumpAlloc only supports trivially destructible types.");
-    return std::construct_at(static_cast<T *>(allocate(sizeof(T), alignof(T))),
+                  "Arena only supports trivially destructible types.");
+    return std::construct_at(static_cast<T *>(allocate(sizeof(T))),
                              std::forward<Args>(args)...);
   }
-  static constexpr auto contains(void *P, void *p) -> bool { return P == p; }
   constexpr void deallocate(void *Ptr, size_t Size) {
     __asan_poison_memory_region(Ptr, Size);
     if constexpr (BumpUp) {
-      if (Ptr + align(Size) == slab) slab = Ptr;
+      if ((char *)Ptr + align(Size) == slab) slab = Ptr;
     } else if (Ptr == slab) {
       slab = (char *)slab + align(Size);
       return;
@@ -109,13 +134,11 @@ public:
   template <typename T> constexpr void deallocate(T *Ptr, size_t N = 1) {
     deallocate((void *)Ptr, N * sizeof(T));
   }
-  constexpr auto tryReallocate(void *Ptr, size_t szOld, size_t szNew,
-                               size_t Align) -> void * {
-    invariant(std::has_single_bit(Align));
-    Align = Align > MinAlignment ? Align : MinAlignment;
+  constexpr auto tryReallocate(void *Ptr, size_t szOld, size_t szNew)
+    -> void * {
     if constexpr (BumpUp) {
-      if (Ptr == slab - align(szOld)) {
-        slab = Ptr + align(szNew);
+      if (Ptr == (char *)slab - align(szOld)) {
+        slab = (char *)Ptr + align(szNew);
         if (!outOfSlab()) {
           __asan_unpoison_memory_region((char *)Ptr + szOld, szNew - szOld);
           __msan_allocated_memory((char *)Ptr + szOld, szNew - szOld);
@@ -123,7 +146,7 @@ public:
         }
       }
     } else if (Ptr == slab) {
-      size_t extraSize = align(szNew - szOld, Align);
+      size_t extraSize = align(szNew - szOld);
       slab = (char *)slab - extraSize;
       if (!outOfSlab()) {
         __asan_unpoison_memory_region(slab, extraSize);
@@ -136,27 +159,24 @@ public:
   template <typename T>
   constexpr auto tryReallocate(T *Ptr, size_t OldSize, size_t NewSize) -> T * {
     return static_cast<T *>(
-      tryReallocate(Ptr, OldSize * sizeof(T), NewSize * sizeof(T), alignof(T)));
+      tryReallocate(Ptr, OldSize * sizeof(T), NewSize * sizeof(T)));
   }
   /// reallocate<ForOverwrite>(void *Ptr, ptrdiff_t OldSize, ptrdiff_t NewSize,
   /// size_t Align) Should be safe with OldSize == 0, as it checks before
   /// copying
   template <bool ForOverwrite = false>
   [[gnu::returns_nonnull, nodiscard]] constexpr auto
-  reallocate(void *Ptr, ptrdiff_t szOld, ptrdiff_t szNew, size_t Align)
-    -> void * {
-    invariant(std::has_single_bit(Align));
+  reallocate(void *Ptr, size_t szOld, size_t szNew) -> void * {
     if (szOld >= szNew) return Ptr;
     if (Ptr) {
-      if (void *p = tryReallocate(Ptr, szOld, szNew, Align)) {
+      if (void *p = tryReallocate(Ptr, szOld, szNew)) {
         if constexpr ((BumpDown) & (!ForOverwrite))
           std::copy_n((char *)Ptr, szOld, (char *)p);
         return p;
       }
-      Align = Align > MinAlignment ? Align : MinAlignment;
       if constexpr (BumpUp) {
-        if (Ptr == slab - align(szOld)) {
-          slab = Ptr + align(szNew);
+        if (Ptr == (char *)slab - align(szOld)) {
+          slab = (char *)Ptr + align(szNew);
           if (!outOfSlab()) {
             __asan_unpoison_memory_region((char *)Ptr + szOld, szNew - szOld);
             __msan_allocated_memory((char *)Ptr + szOld, szNew - szOld);
@@ -164,7 +184,7 @@ public:
           }
         }
       } else if (Ptr == slab) {
-        ptrdiff_t extraSize = align(szNew - szOld, Align);
+        size_t extraSize = align(szNew - szOld);
         slab = (char *)slab - extraSize;
         if (!outOfSlab()) {
           __asan_unpoison_memory_region(slab, extraSize);
@@ -176,7 +196,7 @@ public:
       }
     }
     // we need to allocate new memory
-    auto newPtr = allocate(szNew, Align);
+    auto newPtr = allocate(szNew);
     if (szOld && Ptr) {
       if constexpr (!ForOverwrite)
         std::copy_n((char *)Ptr, szOld, (char *)newPtr);
@@ -185,14 +205,12 @@ public:
     return newPtr;
   }
   constexpr void reset() {
-    resetSlabs();
 #ifdef NDEBUG
-    initSlab(sEnd);
+    resetSlabs();
 #else
-    // we want to increase chance of dangling references getting caught, by
-    // freeing
-    std::free(sEnd);
-    initNewSlab();
+    // catch dangling references
+    freeAllSlabs();
+    initialize();
 #endif
   }
   template <bool ForOverwrite = false, typename T>
@@ -201,23 +219,18 @@ public:
     return static_cast<T *>(reallocate<ForOverwrite>(
       Ptr, OldSize * sizeof(T), NewSize * sizeof(T), alignof(T)));
   }
-  constexpr explicit BumpAlloc() { initNewSlab(); }
-  constexpr explicit BumpAlloc(BumpAlloc &&other) noexcept
-    : slab{other.slab}, sEnd{other.sEnd}, slabs{other.slabs} {
-    other.slab = nullptr;
-    other.sEnd = nullptr;
-    other.slabs = nullptr;
-  }
-  BumpAlloc(const BumpAlloc &) = delete;
-  constexpr ~BumpAlloc() {
-    // need a check because of move
-    // should we even support moving?
-    resetSlabs();
-    if (sEnd) std::free(sEnd);
-  }
+  constexpr explicit Arena() { initialize(); }
+  constexpr explicit Arena(Arena &&other) = delete;
+  //   : slab{other.slab}, sEnd{other.sEnd} {
+  //   other.slab = nullptr;
+  //   other.sEnd = nullptr;
+  // }
+  Arena(const Arena &) = delete;
+  constexpr ~Arena() { freeAllSlabs(); }
+
   template <typename T, typename... Args>
   constexpr auto construct(Args &&...args) -> T * {
-    auto *p = allocate(sizeof(T), alignof(T));
+    auto *p = allocate(sizeof(T));
     return new (p) T(std::forward<Args>(args)...);
   }
   constexpr auto isPointInSlab(void *p) -> bool {
@@ -234,105 +247,81 @@ public:
     return {slab, sEnd};
   }
   constexpr void rollback(CheckPoint p) {
-    if (p.isInSlab(sEnd)) {
 #if MATH_ADDRESS_SANITIZER_BUILD
+    if (p.isInSlab(sEnd)) {
       if constexpr (BumpUp)
         __asan_poison_memory_region(p.p, (char *)slab - (char *)p.p);
       else __asan_poison_memory_region(slab, (char *)p.p - (char *)slab);
+    }
 #endif
-      slab = p.p;
-    } else initSlab(sEnd);
+    slab = p.p;
+    sEnd = p.e;
   }
   /// RAII version of CheckPoint
   class ScopeLifetime {
-    BumpAlloc &alloc;
+    Arena &alloc;
     CheckPoint p;
 
   public:
-    constexpr ScopeLifetime(BumpAlloc &a) : alloc(a), p(a.checkpoint()) {}
+    constexpr ScopeLifetime(Arena &a) : alloc(a), p(a.checkpoint()) {}
     constexpr ~ScopeLifetime() { alloc.rollback(p); }
   };
   constexpr auto scope() -> ScopeLifetime { return *this; }
 
 private:
-  static constexpr auto align(ptrdiff_t x) -> ptrdiff_t {
-    return (x + MinAlignment - 1) & ~(MinAlignment - 1);
-  }
-  static constexpr auto align(ptrdiff_t x, ptrdiff_t alignment) -> ptrdiff_t {
-    return (x + alignment - 1) & ~(alignment - 1);
-  }
-  static constexpr auto align(void *p) -> void * {
-    uint64_t i = reinterpret_cast<uintptr_t>(p), j = i;
-    if constexpr (BumpUp) i += MinAlignment - 1;
-    i &= ~(MinAlignment - 1);
-    return (char *)p + (i - j);
-  }
-  static constexpr auto align(void *p, size_t alignment) -> void * {
-    invariant(std::has_single_bit(alignment));
-    uintptr_t i = reinterpret_cast<uintptr_t>(p), j = i;
-    if constexpr (BumpUp) i += alignment - 1;
-    i &= ~(alignment - 1);
-    return (char *)p + (i - j);
+  constexpr void initialize() {
+    initNewSlab();
+    void **meta = static_cast<void **>(sEnd);
+    meta[0] = nullptr;
+    meta[1] = sEnd; // sEnd is first
   }
   static constexpr auto bump(void *ptr, ptrdiff_t N) -> void * {
     if constexpr (BumpUp) return (char *)ptr + N;
     else return (char *)ptr - N;
   }
-  static constexpr auto outOfSlab(void *cur, void *lst) -> bool {
-    if constexpr (BumpUp) return cur >= lst;
-    else return cur < lst;
+  static constexpr auto outOfSlab(void *current, void *last) -> bool {
+    if constexpr (BumpUp) return current >= last;
+    else return current < last;
   }
   constexpr auto outOfSlab() -> bool { return outOfSlab(slab, getEnd()); }
   constexpr auto getEnd() -> void * {
     if constexpr (BumpUp) return static_cast<char *>(sEnd) + SlabSize;
-    else return sEnd;
+    else return static_cast<char *>(sEnd) + MetaSize;
+  }
+  static constexpr auto initValue(void *p) -> void * {
+    if constexpr (BumpUp) return static_cast<char *>(p) + MetaSize;
+    else return static_cast<char *>(p) + SlabSize;
   }
   constexpr void initSlab(void *p) {
-    __asan_poison_memory_region(p, SlabSize);
-    if constexpr (!BumpUp) {
-      slab = (char *)p + SlabSize;
-      sEnd = p;
-    } else sEnd = slab = p;
-  }
-  constexpr void initNewSlab() {
-    if constexpr (MinAlignment <= alignof(std::max_align_t))
-      initSlab(std::malloc(SlabSize));
-    else initSlab(std::aligned_alloc(MinAlignment, SlabSize));
-  }
-  constexpr void newSlab() {
-    void *old = sEnd;
-    initNewSlab();
-    pushOldSlab(old);
-  }
-  /// stores a slab so we can free it later
-  constexpr void pushOldSlab(void *old) {
-    if (slabs && (!slabs->isFull())) slabs->pushHasCapacity(old);
-    else slabs = create<containers::UList<void *>>(old, slabs);
-  }
-  // updates SlabCur and returns the allocated pointer
-  [[gnu::returns_nonnull]] constexpr auto allocCore(ptrdiff_t Size,
-                                                    size_t Align) -> void * {
+    // poison everything except the meta data
 #if MATH_ADDRESS_SANITIZER_BUILD
-    slab = bump(slab, Align); // poisoned zone
+    __asan_poison_memory_region(static_cast<char *>(p) + MetaSize,
+                                SlabSize - MetaSize);
 #endif
-    if constexpr (BumpUp) {
-      slab = align(slab, Align);
-      void *old = slab;
-      slab = (char *)slab + align(Size);
-      return old;
-    } else {
-      slab = align((char *)slab - Size, Align);
-      return slab;
-    }
+    sEnd = p;
+    slab = initValue(p);
+  }
+  constexpr void initNewSlab() { initSlab(std::malloc(SlabSize)); }
+  constexpr void newSlab(void **oldMeta) {
+    initNewSlab();
+    void **newMeta = static_cast<void **>(sEnd);
+    oldMeta[0] = sEnd;
+    newMeta[0] = nullptr;
+    newMeta[1] = oldMeta[1];
+  }
+  constexpr void nextSlab() {
+    void **meta = static_cast<void **>(sEnd);
+    if (void *p = meta[0]) initSlab(p);
+    else newSlab(meta);
   }
   // updates SlabCur and returns the allocated pointer
   [[gnu::returns_nonnull]] constexpr auto allocCore(ptrdiff_t Size) -> void * {
-    // we know we already have MinAlignment
+    // we know we already have Alignment
     // and we need to preserve it.
     // Thus, we align `Size` and offset it.
-    invariant((reinterpret_cast<ptrdiff_t>(slab) % MinAlignment) == 0);
+    invariant((reinterpret_cast<ptrdiff_t>(slab) % Alignment) == 0);
 #if MATH_ADDRESS_SANITIZER_BUILD
-    slab = bump(slab, MinAlignment); // poisoned zone
+    slab = bump(slab, Alignment); // poisoned zone
 #endif
     if constexpr (BumpUp) {
       void *old = slab;
@@ -343,61 +332,50 @@ private:
       return slab;
     }
   }
-  //
-  [[gnu::returns_nonnull]] constexpr auto bumpAlloc(ptrdiff_t Size,
-                                                    size_t Align) -> void * {
-    invariant(std::has_single_bit(Align));
-    void *ret = allocCore(Size, Align);
-    if (outOfSlab()) [[unlikely]] {
-      newSlab();
-      ret = allocCore(Size, Align);
-    }
-    return ret;
-  }
   [[gnu::returns_nonnull]] constexpr auto bumpAlloc(ptrdiff_t Size) -> void * {
     void *ret = allocCore(Size);
     if (outOfSlab()) [[unlikely]] {
-      newSlab();
+      nextSlab();
       ret = allocCore(Size);
     }
     return ret;
   }
-
-  constexpr void resetSlabs() {
-    if (slabs) slabs->forEachStack([](auto *s) { std::free(s); });
-    slabs = nullptr; // ((void *)slabs == sEnd) ? slabs : nullptr;
+  constexpr void freeAllSlabs() {
+    void *p = static_cast<void **>(sEnd)[1];
+    while (p) {
+      void *next = static_cast<void **>(p)[0];
+      std::free(p);
+      p = next;
+    }
   }
+  constexpr void resetSlabs() { initSlab(static_cast<void **>(sEnd)[1]); }
 
   void *slab{nullptr};
   void *sEnd{nullptr};
-  containers::UList<void *> *slabs{nullptr};
 };
-static_assert(sizeof(BumpAlloc<>) == 24);
-static_assert(!std::is_trivially_copyable_v<BumpAlloc<>>);
-static_assert(!std::is_trivially_destructible_v<BumpAlloc<>>);
-static_assert(
-  std::same_as<std::allocator_traits<BumpAlloc<>>::size_type, size_t>);
+static_assert(sizeof(Arena<>) == 16);
+static_assert(!std::is_trivially_copyable_v<Arena<>>);
+static_assert(!std::is_trivially_destructible_v<Arena<>>);
+static_assert(std::same_as<std::allocator_traits<Arena<>>::size_type, size_t>);
 
 // Alloc wrapper people can pass and store by value
 // with a specific value type, so that it can act more like a
 // `std::allocator`.
-template <typename T, size_t SlabSize = 16384, bool BumpUp = false,
-          ptrdiff_t MinAlignment = alignof(std::max_align_t)>
-class WBumpAlloc {
-  using Alloc = BumpAlloc<SlabSize, BumpUp, MinAlignment>;
+template <typename T, size_t SlabSize = 16384, bool BumpUp = false>
+class WArena {
+  using Alloc = Arena<SlabSize, BumpUp>;
   [[no_unique_address]] NotNull<Alloc> A;
 
 public:
   using value_type = T;
   template <typename U> struct rebind { // NOLINT(readability-identifier-naming)
-    using other = WBumpAlloc<U, SlabSize, BumpUp, MinAlignment>;
+    using other = WArena<U, SlabSize, BumpUp>;
   };
-  constexpr explicit WBumpAlloc(Alloc &alloc) : A(&alloc) {}
-  constexpr explicit WBumpAlloc(NotNull<Alloc> alloc) : A(alloc) {}
-  constexpr explicit WBumpAlloc(const WBumpAlloc &other) = default;
+  constexpr explicit WArena(Alloc &alloc) : A(&alloc) {}
+  constexpr explicit WArena(NotNull<Alloc> alloc) : A(alloc) {}
+  constexpr explicit WArena(const WArena &other) = default;
   template <typename U>
-  constexpr explicit WBumpAlloc(WBumpAlloc<U> other)
-    : A(other.get_allocator()) {}
+  constexpr explicit WArena(WArena<U> other) : A(other.get_allocator()) {}
   [[nodiscard]] constexpr auto get_allocator() const -> NotNull<Alloc> {
     return A;
   }
@@ -410,79 +388,48 @@ public:
   }
   constexpr void rollback(typename Alloc::CheckPoint p) { A->rollback(p); }
 };
-static_assert(std::same_as<
-              std::allocator_traits<WBumpAlloc<int64_t *>>::size_type, size_t>);
 static_assert(
-  std::same_as<std::allocator_traits<WBumpAlloc<int64_t>>::pointer, int64_t *>);
+  std::same_as<std::allocator_traits<WArena<int64_t *>>::size_type, size_t>);
+static_assert(
+  std::same_as<std::allocator_traits<WArena<int64_t>>::pointer, int64_t *>);
 
-static_assert(std::is_trivially_copyable_v<NotNull<BumpAlloc<>>>);
-static_assert(std::is_trivially_copyable_v<WBumpAlloc<int64_t>>);
+static_assert(std::is_trivially_copyable_v<NotNull<Arena<>>>);
+static_assert(std::is_trivially_copyable_v<WArena<int64_t>>);
 
 template <typename A>
-concept Allocator = requires(A a) {
-  typename A::value_type;
-  { a.allocate(1) } -> std::same_as<typename std::allocator_traits<A>::pointer>;
-  {
-    a.deallocate(std::declval<typename std::allocator_traits<A>::pointer>(), 1)
+concept Allocator =
+  requires(A a) {
+    typename A::value_type;
+    {
+      a.allocate(1)
+      } -> std::same_as<typename std::allocator_traits<A>::pointer>;
+    {
+      a.deallocate(std::declval<typename std::allocator_traits<A>::pointer>(),
+                   1)
+    };
   };
-};
-static_assert(Allocator<WBumpAlloc<int64_t>>);
+static_assert(Allocator<WArena<int64_t>>);
 static_assert(Allocator<std::allocator<int64_t>>);
 
 struct NoCheckpoint {};
 
 constexpr auto checkpoint(const auto &) { return NoCheckpoint{}; }
-template <class T> constexpr auto checkpoint(WBumpAlloc<T> alloc) {
+template <class T> constexpr auto checkpoint(WArena<T> alloc) {
   return alloc.checkpoint();
 }
-constexpr auto checkpoint(BumpAlloc<> &alloc) { return alloc.checkpoint(); }
+constexpr auto checkpoint(Arena<> &alloc) { return alloc.checkpoint(); }
 
 constexpr void rollback(const auto &, NoCheckpoint) {}
-template <class T> constexpr void rollback(WBumpAlloc<T> alloc, auto p) {
+template <class T> constexpr void rollback(WArena<T> alloc, auto p) {
   alloc.rollback(p);
 }
-constexpr void rollback(BumpAlloc<> &alloc, auto p) { alloc.rollback(p); }
+constexpr void rollback(Arena<> &alloc, auto p) { alloc.rollback(p); }
 } // namespace poly::utils
-template <size_t SlabSize, bool BumpUp, size_t MinAlignment>
-auto operator new(size_t Size,
-                  poly::utils::BumpAlloc<SlabSize, BumpUp, MinAlignment> &Alloc)
+template <size_t SlabSize, bool BumpUp>
+auto operator new(size_t Size, poly::utils::Arena<SlabSize, BumpUp> &Alloc)
   -> void * {
-  return Alloc.allocate(Size, alignof(std::max_align_t));
+  return Alloc.allocate(Size);
 }
 
-template <size_t SlabSize, bool BumpUp, size_t MinAlignment>
-void operator delete(void *,
-                     poly::utils::BumpAlloc<SlabSize, BumpUp, MinAlignment> &) {
-}
-namespace poly::containers {
-template <typename T>
-[[nodiscard]] constexpr auto UList<T>::push(utils::BumpAlloc<> &alloc, T t)
-  -> UList * {
-  invariant(count <= std::ssize(data));
-  if (!isFull()) {
-    data[count++] = t;
-    return this;
-  }
-  return alloc.create<UList<T>>(t, this);
-}
-/// ordered push
-template <typename T>
-constexpr void UList<T>::push_ordered(utils::BumpAlloc<> &alloc, T t) {
-  invariant(count <= std::ssize(data));
-  if (!isFull()) {
-    data[count++] = t;
-    return;
-  }
-  if (next == nullptr) next = alloc.create<UList<T>>(t);
-  else next->push_ordered(alloc, t);
-}
-template <typename T>
-constexpr auto UList<T>::copy(utils::BumpAlloc<> &alloc) const -> UList<T> * {
-  UList<T> *L = alloc.create<UList<T>>();
-  L->count = count;
-  std::copy(std::begin(data), std::end(data), std::begin(L->data));
-  if (next) L->next = next->copy(alloc);
-  return L;
-}
-
-} // namespace poly::containers
+template <size_t SlabSize, bool BumpUp>
+void operator delete(void *, poly::utils::Arena<SlabSize, BumpUp> &) {}

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -196,7 +196,7 @@ TEST(SquareMatrixTest, BasicAssertions) {
     for (ptrdiff_t i = 0; i < 2; ++i) EXPECT_EQ(B(j, i), 4 * (i + 2) + j);
 }
 TEST(VectorTest, BasicAssertions) {
-  poly::utils::BumpAlloc<> alloc;
+  poly::utils::Arena<> alloc;
   ResizeableView<int64_t, unsigned> x;
   for (size_t i = 0; i < 100; ++i) {
     if (x.getCapacity() <= x.size())

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -196,11 +196,11 @@ TEST(SquareMatrixTest, BasicAssertions) {
     for (ptrdiff_t i = 0; i < 2; ++i) EXPECT_EQ(B(j, i), 4 * (i + 2) + j);
 }
 TEST(VectorTest, BasicAssertions) {
-  poly::utils::Arena<> alloc;
+  poly::utils::OwningArena<> alloc;
   ResizeableView<int64_t, unsigned> x;
   for (size_t i = 0; i < 100; ++i) {
     if (x.getCapacity() <= x.size())
-      x.reserve(alloc, std::max(unsigned(8), 2 * x.size()));
+      x.reserve(&alloc, std::max(unsigned(8), 2 * x.size()));
     x.emplace_back(i);
   }
   EXPECT_EQ(x.size(), 100);

--- a/test/simplex_test.cpp
+++ b/test/simplex_test.cpp
@@ -14,10 +14,10 @@ TEST(SimplexTest, BasicAssertions) {
   // 15 >= 2x + 5y + 3z
   IntMatrix A{"[10 3 2 1; 15 2 5 3]"_mat};
   IntMatrix B{DenseDims{0, 4}};
-  Arena<> alloc;
-  Optional<Simplex *> optS0{Simplex::positiveVariables(alloc, A)};
+  OwningArena<> alloc;
+  Optional<Simplex *> optS0{Simplex::positiveVariables(&alloc, A)};
   EXPECT_TRUE(optS0.hasValue());
-  Optional<Simplex *> optS1{Simplex::positiveVariables(alloc, A, B)};
+  Optional<Simplex *> optS1{Simplex::positiveVariables(&alloc, A, B)};
   EXPECT_TRUE(optS1.hasValue());
   ASSERT(optS0.hasValue());
   ASSERT(optS1.hasValue());
@@ -38,12 +38,12 @@ TEST(SimplexTest, BasicAssertions) {
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(LexMinSmallTest, BasicAssertions) {
-  Arena alloc;
+  OwningArena alloc;
   // -10 == -3x - 2y - z  + s0
   // -15 == -2x - 5y - 3z + s1
   IntMatrix tableau{"[-10 0 1 -1 -2 -3; -15 1 0 -3 -5 -2]"_mat};
   // IntMatrix A{"[-10 -3 -2 -1; -15 -2 -5 -3]"_mat};
-  Simplex *simp{Simplex::create(alloc, 2, 5)};
+  Simplex *simp{Simplex::create(&alloc, 2, 5)};
   simp->getConstraints() << tableau;
   Vector<Rational> sol(5);
   EXPECT_FALSE(simp->initiateFeasible());
@@ -111,7 +111,7 @@ TEST(LexMinSmallTest, BasicAssertions) {
   EXPECT_EQ(sol[last - 4], 15);
 }
 
-auto simplexFromTableau(Arena<> &alloc, IntMatrix &tableau)
+auto simplexFromTableau(Arena<> *alloc, IntMatrix &tableau)
   -> NotNull<Simplex> {
   unsigned numCon = unsigned(tableau.numRow()) - 1;
   unsigned numVar = unsigned(tableau.numCol()) - 1;
@@ -990,8 +990,8 @@ TEST(LexMinSimplexTest, BasicAssertions) {
     "1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ]"_mat};
   // std::cout << "tableau3 =" << tableau << "\n";
   tableau(0, _) << -5859553999884210514;
-  Arena<> alloc;
-  NotNull<Simplex> simp{simplexFromTableau(alloc, tableau)};
+  OwningArena<> alloc;
+  NotNull<Simplex> simp{simplexFromTableau(&alloc, tableau)};
   Vector<Rational> sol(37);
   EXPECT_EQ(sol.size(), 37);
   EXPECT_FALSE(simp->initiateFeasible());
@@ -1025,7 +1025,7 @@ TEST(LexMinSimplexTest, BasicAssertions) {
   }
   {
     // test new simplex
-    NotNull<Simplex> simp2{simplexFromTableau(alloc, tableau)};
+    NotNull<Simplex> simp2{simplexFromTableau(&alloc, tableau)};
     EXPECT_FALSE(simp2->initiateFeasible());
     auto C{simp2->getCost()};
     C[_(0, end - 36)] << 0;
@@ -1272,8 +1272,8 @@ TEST(LexMinSimplexTest2, BasicAssertions) {
     "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 0 "
     "0 0 0 0 0 0 0 0 0 ]"_mat};
   // std::cout << "tableau4 =" << tableau << "\n";
-  Arena<> alloc;
-  NotNull<Simplex> simp{simplexFromTableau(alloc, tableau)};
+  OwningArena<> alloc;
+  NotNull<Simplex> simp{simplexFromTableau(&alloc, tableau)};
   Vector<Rational> sol(15);
   EXPECT_EQ(sol.size(), 15);
   EXPECT_FALSE(simp->initiateFeasible());
@@ -2186,7 +2186,7 @@ TEST(Infesaible, BasicAssertions) {
   C(219, 288) = -1;
   C(219, 294) = 1;
   C(219, 295) = 1;
-  Arena<> alloc;
-  NotNull<Simplex> simp{simplexFromTableau(alloc, C)};
+  OwningArena<> alloc;
+  NotNull<Simplex> simp{simplexFromTableau(&alloc, C)};
   EXPECT_TRUE(simp->initiateFeasible());
 }

--- a/test/simplex_test.cpp
+++ b/test/simplex_test.cpp
@@ -14,7 +14,7 @@ TEST(SimplexTest, BasicAssertions) {
   // 15 >= 2x + 5y + 3z
   IntMatrix A{"[10 3 2 1; 15 2 5 3]"_mat};
   IntMatrix B{DenseDims{0, 4}};
-  BumpAlloc<> alloc;
+  Arena<> alloc;
   Optional<Simplex *> optS0{Simplex::positiveVariables(alloc, A)};
   EXPECT_TRUE(optS0.hasValue());
   Optional<Simplex *> optS1{Simplex::positiveVariables(alloc, A, B)};
@@ -38,7 +38,7 @@ TEST(SimplexTest, BasicAssertions) {
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(LexMinSmallTest, BasicAssertions) {
-  BumpAlloc alloc;
+  Arena alloc;
   // -10 == -3x - 2y - z  + s0
   // -15 == -2x - 5y - 3z + s1
   IntMatrix tableau{"[-10 0 1 -1 -2 -3; -15 1 0 -3 -5 -2]"_mat};
@@ -111,7 +111,7 @@ TEST(LexMinSmallTest, BasicAssertions) {
   EXPECT_EQ(sol[last - 4], 15);
 }
 
-auto simplexFromTableau(BumpAlloc<> &alloc, IntMatrix &tableau)
+auto simplexFromTableau(Arena<> &alloc, IntMatrix &tableau)
   -> NotNull<Simplex> {
   unsigned numCon = unsigned(tableau.numRow()) - 1;
   unsigned numVar = unsigned(tableau.numCol()) - 1;
@@ -990,7 +990,7 @@ TEST(LexMinSimplexTest, BasicAssertions) {
     "1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ]"_mat};
   // std::cout << "tableau3 =" << tableau << "\n";
   tableau(0, _) << -5859553999884210514;
-  BumpAlloc<> alloc;
+  Arena<> alloc;
   NotNull<Simplex> simp{simplexFromTableau(alloc, tableau)};
   Vector<Rational> sol(37);
   EXPECT_EQ(sol.size(), 37);
@@ -1272,7 +1272,7 @@ TEST(LexMinSimplexTest2, BasicAssertions) {
     "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 0 "
     "0 0 0 0 0 0 0 0 0 ]"_mat};
   // std::cout << "tableau4 =" << tableau << "\n";
-  BumpAlloc<> alloc;
+  Arena<> alloc;
   NotNull<Simplex> simp{simplexFromTableau(alloc, tableau)};
   Vector<Rational> sol(15);
   EXPECT_EQ(sol.size(), 15);
@@ -2186,7 +2186,7 @@ TEST(Infesaible, BasicAssertions) {
   C(219, 288) = -1;
   C(219, 294) = 1;
   C(219, 295) = 1;
-  BumpAlloc<> alloc;
+  Arena<> alloc;
   NotNull<Simplex> simp{simplexFromTableau(alloc, C)};
   EXPECT_TRUE(simp->initiateFeasible());
 }

--- a/test/ulist_test.cpp
+++ b/test/ulist_test.cpp
@@ -8,10 +8,10 @@ using namespace poly;
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(UListTest, BasicAssertions) {
-  utils::Arena<> alloc;
+  utils::OwningArena<> alloc;
   auto *list = alloc.create<containers::UList<int64_t>>();
   for (int64_t i = 0; i < 100; ++i) {
-    list = list->push(alloc, i);
+    list = list->push(&alloc, i);
     int64_t s = i * (i + 1) / 2;
     EXPECT_EQ(list->reduce(0, [](int64_t a, int64_t b) { return a + b; }), s);
     int64_t s2 = i * (i + 1) * (2 * i + 1) / 6;

--- a/test/ulist_test.cpp
+++ b/test/ulist_test.cpp
@@ -8,7 +8,7 @@ using namespace poly;
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(UListTest, BasicAssertions) {
-  utils::BumpAlloc<> alloc;
+  utils::Arena<> alloc;
   auto *list = alloc.create<containers::UList<int64_t>>();
   for (int64_t i = 0; i < 100; ++i) {
     list = list->push(alloc, i);


### PR DESCRIPTION
Renaming so that the name reflects the semantics rather than implementation.
Simplifying internals to reduce its size. Next, I plan on making a non-owning subclass (which might have the name `Arena`) that can be passed by value as a means of being a stack-allocator with scope equivalent to the function's body. This is slightly more succinct than using the checkpoint or scope commands.
The allocated slabs are now a linked list, and checkpoint has been made cheaper.