### PR TITLE
Compile-time Literal Static Matrices

### DIFF
--- a/include/Math/Array.hpp
+++ b/include/Math/Array.hpp
@@ -1499,6 +1499,20 @@ struct POLY_MATH_GSL_OWNER ManagedArray : ReallocView<T, S, A> {
     }
     invariant(k == B.getNonZeros().size());
   }
+  constexpr ManagedArray(const ColVector auto &v)
+  requires(MatrixDimension<S>)
+    : BaseT{memory.data(), S(shape(v)), U(N)} {
+    U len = U(this->sz);
+    this->growUndef(len);
+    (*this) << v;
+  }
+  constexpr ManagedArray(const RowVector auto &v)
+  requires(MatrixDimension<S>)
+    : BaseT{memory.data(), S(CartesianIndex(1, v.size())), U(N)} {
+    U len = U(this->sz);
+    this->growUndef(len);
+    (*this) << v;
+  }
 #if !defined(__clang__) && defined(__GNUC__)
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic pop

--- a/include/Math/Array.hpp
+++ b/include/Math/Array.hpp
@@ -9,6 +9,7 @@
 #include "Math/Matrix.hpp"
 #include "Math/MatrixDimensions.hpp"
 #include "Math/Rational.hpp"
+#include "SIMD/Transpose.hpp"
 #include "Utilities/Invariant.hpp"
 #include "Utilities/Optional.hpp"
 #include "Utilities/Reference.hpp"
@@ -50,6 +51,16 @@
 namespace poly::math {
 template <typename S>
 concept Dimension = VectorDimension<S> != MatrixDimension<S>;
+
+static_assert(Dimension<ptrdiff_t>);
+static_assert(Dimension<DenseDims<3, 2>>);
+static_assert(
+  std::same_as<Col<1>, decltype(Col(std::declval<DenseDims<3, 1>>()))>);
+static_assert(Dimension<DenseDims<3, 1>>);
+static_assert(VectorDimension<StridedRange>);
+static_assert(VectorDimension<DenseDims<3, 1>>);
+static_assert(!MatrixDimension<DenseDims<3, 1>>);
+
 template <class T, Dimension S,
           ptrdiff_t N =
             containers::PreAllocStorage<utils::compressed_t<T>, S>(),
@@ -92,12 +103,12 @@ template <typename T, typename P, typename S, typename I>
   using D = decltype(newDim);
   if constexpr (simd::index::issimd<D>) return simd::ref(ptr + offset, newDim);
   else {
-    constexpr bool Compress = !std::same_as<T, std::remove_const_t<P>>;
+    constexpr bool compress = !std::same_as<T, std::remove_const_t<P>>;
     if constexpr (!std::same_as<D, Empty>)
       if constexpr (std::is_const_v<P>)
-        return Array<T, D, Compress>{ptr + offset, newDim};
-      else return MutArray<T, D, Compress>{ptr + offset, newDim};
-    else if constexpr (!Compress) return ptr[offset];
+        return Array<T, D, compress>{ptr + offset, newDim};
+      else return MutArray<T, D, compress>{ptr + offset, newDim};
+    else if constexpr (!compress) return ptr[offset];
     else if constexpr (std::is_const_v<P>) return T::decompress(ptr + offset);
     else return utils::Reference<T>{ptr + offset};
   }
@@ -113,21 +124,28 @@ template <typename T, typename P, typename S, typename R, typename C>
     auto offset = calcOffset(shape, r, c);
     auto newDim = calcNewDim(shape, r, c);
     using D = decltype(newDim);
-    if constexpr (simd::index::issimd<D>)
+    if constexpr (simd::index::issimd<D>) {
+      std::cout << "simdref\n";
       return simd::ref(ptr + offset, newDim);
-    else {
-      constexpr bool Compress = !std::same_as<T, std::remove_const_t<P>>;
+    } else {
+      constexpr bool compress = !std::same_as<T, std::remove_const_t<P>>;
       if constexpr (!std::same_as<D, Empty>)
         if constexpr (std::is_const_v<P>)
-          return Array<T, D, Compress>{ptr + offset, newDim};
-        else return MutArray<T, D, Compress>{ptr + offset, newDim};
-      else if constexpr (!Compress) return ptr[offset];
+          return Array<T, D, compress>{ptr + offset, newDim};
+        else return MutArray<T, D, compress>{ptr + offset, newDim};
+      else if constexpr (!compress) return ptr[offset];
       else if constexpr (std::is_const_v<P>) return T::decompress(ptr + offset);
       else return utils::Reference<T>{ptr + offset};
     }
-  } else if constexpr (std::same_as<S, StridedRange>)
+  } else if constexpr (ColVectorDimension<S>)
     return index<T>(ptr, shape, unwrapRow(wr));
-  else return index<T>(ptr, shape, unwrapCol(wc));
+  else // if constexpr (RowVectorDimension<S>)
+    return index<T>(ptr, shape, unwrapCol(wc));
+  // else if constexpr (std::integral<R>)
+  //   return index<T>(ptr, unwrapRow(Row(shape)), unwrapRow(wr));
+  // else
+  //   return simd::transpose(index<T>(ptr, unwrapRow(Row(shape)),
+  //   unwrapRow(wr)));
 }
 
 template <typename T, bool Column = false> struct SliceIterator {
@@ -1504,7 +1522,8 @@ struct POLY_MATH_GSL_OWNER ManagedArray : ReallocView<T, S, A> {
     : BaseT{memory.data(), S(shape(v)), U(N)} {
     U len = U(this->sz);
     this->growUndef(len);
-    (*this) << v;
+    MutArray<T, decltype(v.dim())>(this->data(), v.dim()) << v;
+    // (*this) << v;
   }
   constexpr ManagedArray(const RowVector auto &v)
   requires(MatrixDimension<S>)

--- a/include/Math/Array.hpp
+++ b/include/Math/Array.hpp
@@ -125,7 +125,6 @@ template <typename T, typename P, typename S, typename R, typename C>
     auto newDim = calcNewDim(shape, r, c);
     using D = decltype(newDim);
     if constexpr (simd::index::issimd<D>) {
-      std::cout << "simdref\n";
       return simd::ref(ptr + offset, newDim);
     } else {
       constexpr bool compress = !std::same_as<T, std::remove_const_t<P>>;

--- a/include/Math/AxisTypes.hpp
+++ b/include/Math/AxisTypes.hpp
@@ -216,8 +216,13 @@ template <ptrdiff_t M> constexpr auto unwrapCol(Col<M> x) {
   if constexpr (M == -1) return ptrdiff_t(x);
   else return std::integral_constant<ptrdiff_t, M>{};
 }
+template <ptrdiff_t M> constexpr auto unwrapStride(RowStride<M> x) {
+  if constexpr (M == -1) return ptrdiff_t(x);
+  else return std::integral_constant<ptrdiff_t, M>{};
+}
 constexpr auto unwrapRow(auto x) { return x; }
 constexpr auto unwrapCol(auto x) { return x; }
+constexpr auto unwrapStride(auto x) { return x; }
 
 template <ptrdiff_t C, ptrdiff_t X>
 constexpr auto operator==(Col<C> c, RowStride<X> x) -> bool {

--- a/include/Math/Indexing.hpp
+++ b/include/Math/Indexing.hpp
@@ -217,6 +217,7 @@ constexpr auto calcNewDim(VectorDimension auto, ScalarIndex auto) -> Empty {
 }
 constexpr auto calcNewDim(SquareDims<>, ptrdiff_t) -> Empty { return {}; }
 constexpr auto calcNewDim(DenseDims<>, ptrdiff_t) -> Empty { return {}; }
+// constexpr auto calcNewDim(auto, ptrdiff_t) -> Empty { return {}; }
 
 constexpr auto calcNewDim(ptrdiff_t len, Range<ptrdiff_t, ptrdiff_t> r)
   -> ptrdiff_t {

--- a/include/Math/MatrixDimensions.hpp
+++ b/include/Math/MatrixDimensions.hpp
@@ -2,7 +2,6 @@
 
 #include "Math/AxisTypes.hpp"
 #include <cstddef>
-#include <cstdint>
 
 namespace poly::math {
 template <ptrdiff_t R = -1> struct SquareDims;
@@ -169,7 +168,10 @@ template <ptrdiff_t R, ptrdiff_t C> struct DenseDims {
   constexpr auto operator=(SquareDims<R> D) -> DenseDims &requires(R == C);
   constexpr explicit operator Row<R>() const { return M; }
   constexpr explicit operator Col<C>() const { return N; }
-  constexpr explicit operator RowStride<C>() const { return {ptrdiff_t{N}}; }
+  constexpr explicit operator RowStride<C>() const {
+    if constexpr (C == -1) return {ptrdiff_t{N}};
+    else return {};
+  }
   template <ptrdiff_t S>
   [[nodiscard]] constexpr auto truncate(Row<S> r) const -> DenseDims {
     invariant(r <= Row{M});
@@ -256,7 +258,10 @@ template <ptrdiff_t R> struct SquareDims {
   // }
   constexpr explicit operator Row<R>() const { return M; }
   constexpr explicit operator Col<R>() const { return {ptrdiff_t(M)}; }
-  constexpr explicit operator RowStride<R>() const { return {ptrdiff_t(M)}; }
+  constexpr explicit operator RowStride<R>() const {
+    if constexpr (R == -1) return {ptrdiff_t(M)};
+    else return {};
+  }
   template <ptrdiff_t S>
   [[nodiscard]] constexpr auto truncate(Row<S> r) const -> DenseDims<S, R> {
     invariant(r <= Row{M});

--- a/include/Math/StaticArrays.hpp
+++ b/include/Math/StaticArrays.hpp
@@ -133,7 +133,6 @@ struct StaticArray : public ArrayOps<T, StaticDims<T, M, N, Compress>,
   constexpr auto operator[](Index<S> auto i) const noexcept -> decltype(auto) {
     return index<T>(data(), S{}, i);
   }
-  // TODO: switch to operator[] when we enable c++23
   // for vectors, we just drop the column, essentially broadcasting
   template <class R, class C>
   constexpr auto operator[](R r, C c) const noexcept -> decltype(auto) {

--- a/include/Math/StaticArrays.hpp
+++ b/include/Math/StaticArrays.hpp
@@ -617,6 +617,7 @@ StaticArray(T, U...) -> StaticArray<T, 1, 1 + sizeof...(U)>;
 
 static_assert(utils::Compressible<SVector<int64_t, 3>>);
 static_assert(utils::Compressible<SVector<int64_t, 7>>);
+
 } // namespace poly::math
 
 template <class T, ptrdiff_t N> // NOLINTNEXTLINE(cert-dcl58-cpp)

--- a/include/SIMD/Intrin.hpp
+++ b/include/SIMD/Intrin.hpp
@@ -833,6 +833,10 @@ template <ptrdiff_t W, std::integral T> constexpr auto crz(Vec<W, T> v) {
 template <typename T>
 static constexpr ptrdiff_t Width =
   SIMDSupported<T> ? VECTORWIDTH / sizeof(T) : 1;
+template <ptrdiff_t N, typename T>
+constexpr ptrdiff_t VecLen =
+  (N < Width<T>) ? ptrdiff_t(std::bit_ceil(size_t(N)))
+                 : std::max(Width<T>, ptrdiff_t(1));
 
 // returns { vector_size, num_vectors, remainder }
 template <ptrdiff_t L, typename T>

--- a/include/SIMD/Intrin.hpp
+++ b/include/SIMD/Intrin.hpp
@@ -26,7 +26,8 @@ concept SIMDSupported = std::same_as<T, int64_t> || std::same_as<T, double>;
 
 template <ptrdiff_t W, typename T>
 [[gnu::always_inline]] constexpr auto vbroadcast(Vec<W, T> v) -> Vec<W, T> {
-  if constexpr (W == 2) return __builtin_shufflevector(v, v, 0, 0);
+  if constexpr (W == 1) return v;
+  else if constexpr (W == 2) return __builtin_shufflevector(v, v, 0, 0);
   else if constexpr (W == 4) return __builtin_shufflevector(v, v, 0, 0, 0, 0);
   else if constexpr (W == 8)
     return __builtin_shufflevector(v, v, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -46,7 +47,13 @@ template <ptrdiff_t W, typename T>
 }
 template <ptrdiff_t W, typename T>
 [[gnu::always_inline]] constexpr auto vbroadcast(T x) -> Vec<W, T> {
-  return vbroadcast<W, T>(Vec<W, T>{x});
+  if constexpr (W > 1) {
+    if consteval {
+      return Vec<W, T>{} + x;
+    } else {
+      return vbroadcast<W, T>(Vec<W, T>{x});
+    }
+  } else return x;
 }
 
 template <typename T>

--- a/include/SIMD/Transpose.hpp
+++ b/include/SIMD/Transpose.hpp
@@ -5,6 +5,13 @@
 #include "SIMD/Unroll.hpp"
 namespace poly::simd {
 
+template <ptrdiff_t C, typename T>
+constexpr auto transpose(Unroll<1, C, 1, T> u) -> Unroll<C, 1, 1, T> {
+  Unroll<C, 1, 1, T> z;
+  POLYMATHFULLUNROLL
+  for (ptrdiff_t i = 0; i < C; ++i) z[i] = u[i];
+  return z;
+}
 // 4 x 4C -> 4C x 4
 template <ptrdiff_t C, typename T>
 constexpr auto transpose(Unroll<2, C, 2, T> u) -> Unroll<2 * C, 1, 2, T> {

--- a/include/SIMD/Unroll.hpp
+++ b/include/SIMD/Unroll.hpp
@@ -503,7 +503,6 @@ loadunroll(const T *ptr, math::RowStride<X> rowStride, std::array<MT, NM> masks)
   else {
     constexpr auto W = ptrdiff_t(std::bit_ceil(size_t(N)));
     auto rs = ptrdiff_t(rowStride);
-    std::cout << "RowStride=" << rs << "\n";
     Unroll<R, C, N, T> ret;
     POLYMATHFULLUNROLL
     for (ptrdiff_t r = 0; r < R; ++r, ptr += rs) {

--- a/include/Utilities/Assign.hpp
+++ b/include/Utilities/Assign.hpp
@@ -22,32 +22,32 @@ template <typename D, typename S, typename Op>
 template <typename D, typename S, typename R, typename C, typename Op>
 [[gnu::always_inline]] constexpr void assign(D &d, const S &s, R r, C c,
                                              Op op) {
-  constexpr bool norowind = std::same_as<R, NoRowIndex>;
+  constexpr bool noRowInd = std::same_as<R, NoRowIndex>;
   if constexpr (std::convertible_to<S, utils::eltype_t<D>>)
-    if constexpr (norowind) assign(d[c], s, op);
+    if constexpr (noRowInd) assign(d[c], s, op);
     else assign(d[r, c], s, op);
   else if constexpr (math::RowVector<S>)
-    if constexpr (norowind) assign(d[c], s[c], op);
+    if constexpr (noRowInd) assign(d[c], s[c], op);
     else assign(d[r, c], s[c], op);
   else if constexpr (math::ColVector<S>)
-    if constexpr (norowind) assign(d[c], s[c], op);
+    if constexpr (noRowInd) assign(d[c], s[c], op);
     else assign(d[r, c], s[r], op);
   else if constexpr (std::same_as<Op, CopyAssign>)
-    if constexpr (norowind) d[c] = s[c];
+    if constexpr (noRowInd) d[c] = s[c];
     else d[r, c] = s[r, c];
   else if constexpr (std::same_as<Op, std::plus<>>)
-    if constexpr (norowind) d[c] += s[c];
+    if constexpr (noRowInd) d[c] += s[c];
     else d[r, c] += s[r, c];
   else if constexpr (std::same_as<Op, std::minus<>>)
-    if constexpr (norowind) d[c] -= s[c];
+    if constexpr (noRowInd) d[c] -= s[c];
     else d[r, c] -= s[r, c];
   else if constexpr (std::same_as<Op, std::multiplies<>>)
-    if constexpr (norowind) d[c] *= s[c];
+    if constexpr (noRowInd) d[c] *= s[c];
     else d[r, c] *= s[r, c];
   else if constexpr (std::same_as<Op, std::divides<>>)
-    if constexpr (norowind) d[c] /= s[c];
+    if constexpr (noRowInd) d[c] /= s[c];
     else d[r, c] /= s[r, c];
-  else if constexpr (norowind) d[c] = op(const_cast<const D &>(d)[c], s[c]);
+  else if constexpr (noRowInd) d[c] = op(const_cast<const D &>(d)[c], s[c]);
   else d[r, c] = op(const_cast<const D &>(d)[r, c], s[r, c]);
 }
 

--- a/include/Utilities/MatrixStringParse.hpp
+++ b/include/Utilities/MatrixStringParse.hpp
@@ -37,11 +37,7 @@ template <std::size_t N> struct String {
 };
 
 // returns an array {nrows, ncols}
-#ifndef CONSTEVAL_LITERAL_ARRAYS
-template <String S> constexpr auto dims_eltype() -> std::array<ptrdiff_t, 2> {
-#else
 template <String S> consteval auto dims_eltype() -> std::array<ptrdiff_t, 2> {
-#endif
   ptrdiff_t numRows = 1, numCols = 0;
   // count numCols
   const char *s = S.data + 1; // skip `[`

--- a/include/Utilities/MatrixStringParse.hpp
+++ b/include/Utilities/MatrixStringParse.hpp
@@ -6,26 +6,26 @@
 #include <cstddef>
 #include <cstdint>
 
-#if !defined(__clang__)
+// #if !defined(__clang__)
 #define CONSTEVAL_LITERAL_ARRAYS
-#endif
+// #endif
 
 namespace poly::utils {
 
-constexpr auto cstoll(const char *s, ptrdiff_t &cur) -> int64_t {
-  int64_t res = 0;
-  bool neg = false;
-  while (s[cur] == ' ') ++cur;
-  if (s[cur] == '-') {
-    neg = true;
-    ++cur;
-  }
-  while (s[cur] >= '0' && s[cur] <= '9') {
-    res = res * 10 + (s[cur] - '0');
-    ++cur;
-  }
-  return neg ? -res : res;
-}
+// constexpr auto cstoll(const char *s, ptrdiff_t &cur) -> int64_t {
+//   int64_t res = 0;
+//   bool neg = false;
+//   while (s[cur] == ' ') ++cur;
+//   if (s[cur] == '-') {
+//     neg = true;
+//     ++cur;
+//   }
+//   while (s[cur] >= '0' && s[cur] <= '9') {
+//     res = res * 10 + (s[cur] - '0');
+//     ++cur;
+//   }
+//   return neg ? -res : res;
+// }
 
 // static_assert(__cpp_nontype_template_args >= 201911);
 template <std::size_t N> struct String {
@@ -69,21 +69,21 @@ template <String S> constexpr auto matrix_from_string() {
 template <String S> consteval auto matrix_from_string() {
 #endif
   constexpr std::array<ptrdiff_t, 2> dims = dims_eltype<S>();
-  math::StaticArray<int64_t, dims[0], dims[1]> A(int64_t(0));
-  ptrdiff_t cur = 1, i = 0, j = 0;
+  math::StaticArray<int64_t, dims[0], dims[1], true> A(int64_t(0));
   const char *s = S.data;
-  while (s[cur] != ']') {
-    switch (s[cur]) {
-    case ';': [[fallthrough]];
-    case ' ': ++cur; break;
-    default: {
-      int64_t x = cstoll(s, cur);
-      A.set(x, i, j);
-      if (++j == dims[1]) {
-        j = 0;
-        ++i;
+  for (ptrdiff_t i = 0; i < dims[0]; ++i) {
+    for (ptrdiff_t j = 0; j < dims[1]; ++j) {
+      int64_t x = 0;
+      char c = *s;
+      while (c != '-' && (c < '0' || c > '9')) c = *(++s);
+      bool neg = c == '-';
+      if (neg) c = *(++s);
+      while (c >= '0' && c <= '9') {
+        x = x * 10 + (c - '0');
+        c = *(++s);
       }
-    }
+      if (neg) x = -x;
+      A.set(x, i, j);
     }
   }
   return A;

--- a/include/Utilities/MatrixStringParse.hpp
+++ b/include/Utilities/MatrixStringParse.hpp
@@ -33,7 +33,11 @@ template <std::size_t N> struct String {
 };
 
 // returns an array {nrows, ncols}
+#if defined(__clang__)
+template <String S> constexpr auto dims_eltype() -> std::array<ptrdiff_t, 2> {
+#else
 template <String S> consteval auto dims_eltype() -> std::array<ptrdiff_t, 2> {
+#endif
   ptrdiff_t numRows = 1, numCols = 0;
   // count numCols
   const char *s = S.data + 1; // skip `[`
@@ -59,9 +63,13 @@ template <String S> consteval auto dims_eltype() -> std::array<ptrdiff_t, 2> {
   }
 }
 
+#if defined(__clang__)
 template <String S> constexpr auto matrix_from_string() {
+#else
+template <String S> consteval auto matrix_from_string() {
+#endif
   constexpr std::array<ptrdiff_t, 2> dims = dims_eltype<S>();
-  math::StaticArray<int64_t, dims[0], dims[1]> A{0};
+  math::StaticArray<int64_t, dims[0], dims[1]> A(int64_t(0));
   ptrdiff_t cur = 1, i = 0, j = 0;
   const char *s = S.data;
   while (s[cur] != ']') {
@@ -70,7 +78,7 @@ template <String S> constexpr auto matrix_from_string() {
     case ' ': ++cur; break;
     default: {
       int64_t x = cstoll(s, cur);
-      A[i, j] = x;
+      A.set(x, i, j);
       if (++j == dims[1]) {
         j = 0;
         ++i;
@@ -81,7 +89,11 @@ template <String S> constexpr auto matrix_from_string() {
   return A;
 }
 
+#if defined(__clang__)
 template <String S> [[nodiscard]] constexpr auto operator"" _mat() {
+#else
+template <String S> [[nodiscard]] consteval auto operator"" _mat() {
+#endif
   return matrix_from_string<S>();
 }
 

--- a/include/Utilities/MatrixStringParse.hpp
+++ b/include/Utilities/MatrixStringParse.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Math/Array.hpp"
-#include "Math/MatrixDimensions.hpp"
 #include "Math/StaticArrays.hpp"
 #include <cstddef>
 #include <cstdint>

--- a/include/Utilities/MatrixStringParse.hpp
+++ b/include/Utilities/MatrixStringParse.hpp
@@ -52,13 +52,20 @@ template <String S> consteval auto dims_eltype() -> std::array<ptrdiff_t, 2> {
 template <String S> constexpr auto matrix_from_string() {
   constexpr std::array<ptrdiff_t, 2> dims = dims_eltype<S>();
   math::StaticArray<int64_t, dims[0], dims[1]> A;
-  ptrdiff_t cur = 1, i = 0;
+  ptrdiff_t cur = 1, i = 0, j = 0;
   const char *s = S.data;
   while (s[cur] != ']') {
     switch (s[cur]) {
     case ';': [[fallthrough]];
     case ' ': ++cur; break;
-    default: A.data()[i++] = cstoll(s, cur);
+    default: {
+      int64_t x = cstoll(s, cur);
+      A[i, j] = x;
+      if (++j == dims[1]) {
+        j = 0;
+        ++i;
+      }
+    }
     }
   }
   return A;

--- a/include/Utilities/MatrixStringParse.hpp
+++ b/include/Utilities/MatrixStringParse.hpp
@@ -6,6 +6,10 @@
 #include <cstddef>
 #include <cstdint>
 
+#if !defined(__clang__)
+#define CONSTEVAL_LITERAL_ARRAYS
+#endif
+
 namespace poly::utils {
 
 constexpr auto cstoll(const char *s, ptrdiff_t &cur) -> int64_t {
@@ -33,7 +37,7 @@ template <std::size_t N> struct String {
 };
 
 // returns an array {nrows, ncols}
-#if defined(__clang__)
+#ifndef CONSTEVAL_LITERAL_ARRAYS
 template <String S> constexpr auto dims_eltype() -> std::array<ptrdiff_t, 2> {
 #else
 template <String S> consteval auto dims_eltype() -> std::array<ptrdiff_t, 2> {
@@ -63,7 +67,7 @@ template <String S> consteval auto dims_eltype() -> std::array<ptrdiff_t, 2> {
   }
 }
 
-#if defined(__clang__)
+#ifndef CONSTEVAL_LITERAL_ARRAYS
 template <String S> constexpr auto matrix_from_string() {
 #else
 template <String S> consteval auto matrix_from_string() {
@@ -89,7 +93,7 @@ template <String S> consteval auto matrix_from_string() {
   return A;
 }
 
-#if defined(__clang__)
+#ifndef CONSTEVAL_LITERAL_ARRAYS
 template <String S> [[nodiscard]] constexpr auto operator"" _mat() {
 #else
 template <String S> [[nodiscard]] consteval auto operator"" _mat() {

--- a/test/unimodularization_test.cpp
+++ b/test/unimodularization_test.cpp
@@ -9,22 +9,27 @@ using poly::utils::operator""_mat;
 
 // NOLINTNEXTLINE(modernize-use-trailing-return-type)
 TEST(UnimodularizationTest, BasicAssertions) {
+  /*
   IntMatrix<> VE{"[0 1; 1 0; 0 1; 1 0]"_mat};
-  std::cout << "VE=\n" << VE << "\n";
+  std::cout << "VE=" << VE << "\n";
   auto VB = unimodularize(VE);
   EXPECT_TRUE(VB.has_value());
   ASSERT(VB.has_value());
-  std::cout << "VB:\n" << *VB << "\n";
+  std::cout << "VB=" << *VB << "\n";
 
   IntMatrix<> A23{"[9 5; -5 -2; 1 0]"_mat};
   auto B = unimodularize(A23);
   EXPECT_TRUE(B.has_value());
   ASSERT(B.has_value());
-  std::cout << "B:\n" << *B << "\n";
+  std::cout << "B=" << *B << "\n";
   // EXPECT_EQ(j, length(bsc));
   // EXPECT_EQ(j, length(bs));
-
+*/
   IntMatrix<> A13{"[6; -5; 15]"_mat};
+  std::cout << "A13=" << A13 << "\n";
+  EXPECT_EQ((A13[0, 0]), 6);
+  EXPECT_EQ((A13[1, 0]), -5);
+  EXPECT_EQ((A13[2, 0]), 15);
   auto test6_10_15 = unimodularize(A13); //, 1, 93, 1001);
   EXPECT_TRUE(test6_10_15.has_value());
   A13[0, 0] = 102;


### PR DESCRIPTION
Currently, `consteval` works with GCC but not Clang.

@sumiya11, we talked about getting this to work some time ago.
Not important, but cool to have.